### PR TITLE
fix: use uintptr for file descriptor

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -32,7 +32,7 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         go-version: ${{ matrix.go }}
-    - run: go vet -unsafeptr=false
+    - run: go vet
     - run: go test
     - run: go test -tags debug
     # - run: go test -tags debug

--- a/ci/download-wasmtime.py
+++ b/ci/download-wasmtime.py
@@ -10,7 +10,7 @@ import os
 import shutil
 import glob
 
-version = 'v12.0.2-wasictx'
+version = 'v12.0.2-uintptr-t'
 urls = [
     ['wasmtime-{}-x86_64-mingw-c-api.zip', 'windows-x86_64'],
     ['wasmtime-{}-x86_64-linux-c-api.tar.xz', 'linux-x86_64'],

--- a/store.go
+++ b/store.go
@@ -338,7 +338,7 @@ func (store *Store) WasiCtx() *WasiCtx {
 }
 
 func (store *Store) InsertFile(guestFD uint32, file *os.File, accessMode WasiFileAccessMode) error {
-	err := C.wasmtime_context_insert_file(store.Context(), C.uint32_t(guestFD), unsafe.Pointer(file.Fd()), C.uint32_t(accessMode))
+	err := C.wasmtime_context_insert_file(store.Context(), C.uint32_t(guestFD), C.uintptr_t(file.Fd()), C.uint32_t(accessMode))
 	runtime.KeepAlive(store)
 	runtime.KeepAlive(file)
 	if err != nil {
@@ -351,7 +351,7 @@ func (store *Store) PushFile(file *os.File, accessMode WasiFileAccessMode) (uint
 	var guestFd uint32
 	c_guest_fd := C.uint32_t(guestFd)
 
-	err := C.wasmtime_context_push_file(store.Context(), unsafe.Pointer(file.Fd()), C.uint32_t(accessMode), &c_guest_fd)
+	err := C.wasmtime_context_push_file(store.Context(), C.uintptr_t(file.Fd()), C.uint32_t(accessMode), &c_guest_fd)
 	runtime.KeepAlive(store)
 	runtime.KeepAlive(file)
 	if err != nil {

--- a/wasi.go
+++ b/wasi.go
@@ -183,7 +183,7 @@ func (ctx *WasiCtx) ptr() *C.wasi_ctx_t {
 }
 
 func (ctx *WasiCtx) InsertFile(guestFD uint32, file *os.File, accessMode WasiFileAccessMode) error {
-	err := C.wasi_ctx_insert_file(ctx.ptr(), C.uint32_t(guestFD), unsafe.Pointer(file.Fd()), C.uint32_t(accessMode))
+	err := C.wasi_ctx_insert_file(ctx.ptr(), C.uint32_t(guestFD), C.uintptr_t(file.Fd()), C.uint32_t(accessMode))
 	runtime.KeepAlive(ctx)
 	runtime.KeepAlive(file)
 	if err != nil {
@@ -196,7 +196,7 @@ func (ctx *WasiCtx) PushFile(file *os.File, accessMode WasiFileAccessMode) (uint
 	var guestFd uint32
 	c_guest_fd := C.uint32_t(guestFd)
 
-	err := C.wasi_ctx_push_file(ctx.ptr(), unsafe.Pointer(file.Fd()), C.uint32_t(accessMode), &c_guest_fd)
+	err := C.wasi_ctx_push_file(ctx.ptr(), C.uintptr_t(file.Fd()), C.uint32_t(accessMode), &c_guest_fd)
 	runtime.KeepAlive(ctx)
 	runtime.KeepAlive(file)
 	if err != nil {


### PR DESCRIPTION
This will fix the `misuse of unsafe.Pointer` error from `go vet`, as well as its potential downsides. 

Fix #2. 